### PR TITLE
Error is no longer thrown in case of no comments

### DIFF
--- a/Models/ContentManager.php
+++ b/Models/ContentManager.php
@@ -262,8 +262,10 @@ class ContentManager
 			array(inet_pton($ip), $userId), true);
 		
 		$ids = array();
-		foreach ($result as $commentId) {
-			$ids[] = $commentId['comment_id'];
+		if ($result !== false) {
+			foreach ($result as $commentId) {
+				$ids[] = $commentId['comment_id'];
+			}
 		}
 		return $ids;
 	}


### PR DESCRIPTION
What the title says.

Wasn't tested, but I can't see how this wouldn't work. Let me know if you find any problems.