### PR TITLE
Card spacing on the credits webpage

### DIFF
--- a/Controllers/Credits.php
+++ b/Controllers/Credits.php
@@ -22,7 +22,8 @@ class Credits extends Controller
 		self::$data['credits_contributors'] = $cnm->getContributors();
 		
 		self::$cssFiles[] = 'credits';
-        self::$jsFiles[] = 'font_rescale';
+	    self::$jsFiles[] = 'credits';
+	    self::$jsFiles[] = 'font_rescale';
         self::$views[] = 'credits';
         return true;
     }

--- a/Views/credits.phtml
+++ b/Views/credits.phtml
@@ -1,6 +1,8 @@
 <h1>Contributors</h1>
 <p style="text-align: center;">A lot of people worked hard on this mod. Take a moment to appreciate their effort and find out who helped.</p>
-<?php $currentHighestRole = null; ?>
+<?php $currentHighestRole = ${basename(__FILE__, '.phtml').'_contributors'}[0]->getRoles()[0]->name; ?>
+<hr>
+<h2>Owner</h2>
 <div class="row">
 <?php foreach (${basename(__FILE__, '.phtml').'_contributors'} as $contributor) : ?>
 	<?php
@@ -11,11 +13,11 @@
     </div> <!-- ending for <div class="row"> -->
     <hr>
 	<h2><?= $contributor->getRoles()[0]->name ?><?php if ($contributor->getRoles()[0]->name !== 'Owner') : ?>s<?php endif ?></h2>
-<div class="row" id="credits0">
+<div class="row">
 	<?php endif ?>
-	<div class="cardwrapper" id="credits1">
-	<div class="col-3" id="credits2"><a class="cardlink" href="/cast/<?= $contributor->getId(); ?>">
-		<div class="card" id="credits3">
+	<div class="cardwrapper">
+	<div class="col-3"><a class="cardlink" href="/cast/<?= $contributor->getId(); ?>">
+		<div class="card">
 			<img class="avatar" src="dynamic/avatars/<?= $contributor->getAvatarLink(); ?>" alt="Contributor's profile picture" /><br>
 			<p class="contributor_name"><strong><?= $contributor->getName(); ?></strong></p>
 				<hr> 

--- a/css/credits.css
+++ b/css/credits.css
@@ -66,8 +66,9 @@ a>.card:hover {
 }
 
 .cardwrapper {
-    height: 400px;
+    height: 400px; /* Default value that is changed by JavaScript once the webpage fully loads */
     width: 25%;
+    margin-bottom: 10px;
 }
 
 a:hover .roles {

--- a/js/credits.js
+++ b/js/credits.js
@@ -1,11 +1,12 @@
 $(function () {
-    let $rows = $(".row");
-    Object.keys($rows).forEach(key => {
-        let $cards = $($rows.get(key)).find(".card");
+    let $groups = $(".row");
+    for (let h = 0; h < $groups.length; h++) {
+        let $cards = $($groups.get(h)).find(".card");
         let currentMaxHeight = 0;
-        console.log($cards.length);
         for (let i = 0; i < $cards.length; i++) {
             let $currentCard = $($cards.get(i));
+
+            console.log($currentCard.find("strong").text() + ":" + $currentCard.outerHeight())
             if ($currentCard.outerHeight() > currentMaxHeight) {
                 currentMaxHeight = $currentCard.outerHeight();
             }
@@ -16,18 +17,16 @@ $(function () {
                 for (j = indexOfFirstCardOnCurrentRow; j < $cards.length; j++) {
                     $($cards[j].closest(".cardwrapper")).height(currentMaxHeight + "px");
                 }
-                console.log("Row terminated early: " + currentMaxHeight);
             }
 
             //If we're on the fourth (last) card in the row
-            if (i+1 % 4 === 0) {
+            if ((i+1) % 4 === 0) {
                 let indexOfFirstCardOnCurrentRow = i - 3;
-                for (j = indexOfFirstCardOnCurrentRow; j < i; j++) {
+                for (j = indexOfFirstCardOnCurrentRow; j <= i; j++) {
                     $($cards[j].closest(".cardwrapper")).height(currentMaxHeight + "px");
                 }
-                console.log("Top height in current row: " + currentMaxHeight);
                 currentMaxHeight = 0;
             }
         }
-    });
+    }
 });

--- a/js/credits.js
+++ b/js/credits.js
@@ -1,0 +1,33 @@
+$(function () {
+    let $rows = $(".row");
+    Object.keys($rows).forEach(key => {
+        let $cards = $($rows.get(key)).find(".card");
+        let currentMaxHeight = 0;
+        console.log($cards.length);
+        for (let i = 0; i < $cards.length; i++) {
+            let $currentCard = $($cards.get(i));
+            if ($currentCard.outerHeight() > currentMaxHeight) {
+                currentMaxHeight = $currentCard.outerHeight();
+            }
+
+            //If we're on the last card of the group
+            if (i+1 === $cards.length) {
+                let indexOfFirstCardOnCurrentRow = i - (i % 4);
+                for (j = indexOfFirstCardOnCurrentRow; j < $cards.length; j++) {
+                    $($cards[j].closest(".cardwrapper")).height(currentMaxHeight + "px");
+                }
+                console.log("Row terminated early: " + currentMaxHeight);
+            }
+
+            //If we're on the fourth (last) card in the row
+            if (i+1 % 4 === 0) {
+                let indexOfFirstCardOnCurrentRow = i - 3;
+                for (j = indexOfFirstCardOnCurrentRow; j < i; j++) {
+                    $($cards[j].closest(".cardwrapper")).height(currentMaxHeight + "px");
+                }
+                console.log("Top height in current row: " + currentMaxHeight);
+                currentMaxHeight = 0;
+            }
+        }
+    });
+});


### PR DESCRIPTION
The space between rows is now dynamically changed by JavaScript once the webpage loads.

This works in the vast majority of times, but here and there there's a card that is seen smaller than it actually is by JavaScript which causes mild overflowing. Can't find a fix for this now, maybe somebody will find a way to fix it later.